### PR TITLE
Drop support for Julia 0.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - julia_version: 0.7
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
-  - 0.7
   - 1.0
+  - 1.1
   - nightly
 matrix:
   allow_failures:
@@ -15,17 +14,4 @@ matrix:
 notifications:
   email: false
 after_success:
-  - |
-    julia -e '
-      VERSION >= v"0.7.0-DEV.3656" && import Pkg
-      VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("RemoteSemaphores"))
-      Pkg.add("Coverage"); using Coverage
-      Codecov.submit(process_folder())'
-  - |
-    julia -e 'VERSION >= v"0.7.0-DEV.3656" && import Pkg
-      Pkg.add("Documenter");'
-  - |
-    julia -e '
-      VERSION >= v"0.7.0-DEV.3656" && import Pkg
-      VERSION >= v"0.7.0-DEV.5183" || cd(Pkg.dir("RemoteSemaphores"))
-      include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,12 @@
+name = "RemoteSemaphores"
+uuid = "bcdc7952-6eb0-55db-bf57-82111c48552b"
+
+[deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[extras]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Dates", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 0.50
+julia 0.7

--- a/src/RemoteSemaphores.jl
+++ b/src/RemoteSemaphores.jl
@@ -1,10 +1,9 @@
-__precompile__()
 module RemoteSemaphores
 
 export RemoteSemaphore, acquire, release
 
 using Base: Semaphore, acquire, release
-using Compat.Distributed
+using Distributed
 
 """
     RemoteSemaphore(n::Int, pid=myid())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,17 @@ include("utils.jl")
         @test "Expected error but no error thrown" == nothing
     catch err
         @test err isa RemoteException
-        @test err.captured.ex isa AssertionError
 
-        if !isa(err, RemoteException) || !isa(err.captured.ex, AssertionError)
+        if VERSION >= v"1.2.0-DEV.28"
+            expected = ErrorException
+            @test err.captured.ex isa expected
+            @test occursin("release count must match acquire count", err.captured.ex.msg)
+        else
+            expected = AssertionError
+            @test err.captured.ex isa expected
+        end
+
+        if !isa(err, RemoteException) || !isa(err.captured.ex, expected)
             rethrow(err)
         end
     end
@@ -80,9 +88,17 @@ end
             @test "Expected error but no error thrown" == nothing
         catch err
             @test err isa RemoteException
-            @test err.captured.ex isa AssertionError
 
-            if !isa(err, RemoteException) || !isa(err.captured.ex, AssertionError)
+            if VERSION >= v"1.2.0-DEV.28"
+                expected = ErrorException
+                @test err.captured.ex isa expected
+                @test occursin("release count must match acquire count", err.captured.ex.msg)
+            else
+                expected = AssertionError
+                @test err.captured.ex isa expected
+            end
+
+            if !isa(err, RemoteException) || !isa(err.captured.ex, expected)
                 rethrow(err)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,9 @@
 using RemoteSemaphores
 using RemoteSemaphores: _current_count
-using Compat.Test
+using Test
 
-using Compat.Dates
-using Compat.Distributed
-using Compat: @info
+using Dates
+using Distributed
 
 include("utils.jl")
 
@@ -18,7 +17,6 @@ include("utils.jl")
     @test string(rsem) == "$(typeof(rsem))(2, pid=$(myid()))"
 
     try
-        @info("Expect \"ERROR (unhandled task failure)\" on Julia 0.6 only")
         asynctimedwait(1.0; kill=true) do
             release(rsem)
         end
@@ -76,7 +74,6 @@ end
         @test string(rsem) == "$(typeof(rsem))(2, pid=$worker_pid)"
 
         try
-            @info("Expect \"ERROR (unhandled task failure)\" on Julia 0.6 only")
             asynctimedwait(1.0; kill=true) do
                 release(rsem)
             end


### PR DESCRIPTION
Summary of changes:
* Raise the minimum Julia version to 0.7
* Replace CI testing on 0.6 and 0.7 with 1.1
* Add a Project.toml
* Drop the dependency on Compat
* Remove unnecessary precompile annotation
* Remove outdated info messages regarding 0.6 behavior